### PR TITLE
Create CodigoUtils_test.java added

### DIFF
--- a/supplier-api/src/test/java/com/example/supplier/CodigoUtils_test.java
+++ b/supplier-api/src/test/java/com/example/supplier/CodigoUtils_test.java
@@ -1,0 +1,114 @@
+package com.example.supplier;
+
+import com.example.supplier.util.CodigoUtil;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@SpringBootTest
+class SupplierApplicationTests {
+
+    @Test
+    void contextLoads() {
+    }
+
+    @Test
+    void isValidCNPJ_ShouldReturnTrueForValidCNPJ() {
+        long validCNPJ = 12345678000195L; // Example valid CNPJ
+        assertTrue(CodigoUtil.isValidCNPJ(validCNPJ), "Expected valid CNPJ to return true");
+    }
+
+    @Test
+    void isValidCNPJ_ShouldReturnFalseForInvalidCNPJ() {
+        long invalidCNPJ = 12345678000194L; // Example invalid CNPJ
+        assertFalse(CodigoUtil.isValidCNPJ(invalidCNPJ), "Expected invalid CNPJ to return false");
+    }
+
+    @Test
+    void isValidCNPJ_ShouldReturnFalseForShortCNPJ() {
+        long shortCNPJ = 12345678L; // Example short CNPJ
+        assertFalse(CodigoUtil.isValidCNPJ(shortCNPJ), "Expected short CNPJ to return false");
+    }
+
+    @Test
+    void isValidCNPJ_ShouldReturnFalseForLongCNPJ() {
+        long longCNPJ = 123456789012345L; // Example long CNPJ
+        assertFalse(CodigoUtil.isValidCNPJ(longCNPJ), "Expected long CNPJ to return false");
+    }
+
+    @Test
+    void isValidCNPJ_ShouldReturnFalseForNonNumericCNPJ() {
+        long nonNumericCNPJ = -12345678000195L; // Example non-numeric CNPJ
+        assertFalse(CodigoUtil.isValidCNPJ(nonNumericCNPJ), "Expected non-numeric CNPJ to return false");
+    }
+
+    @Test
+    void isValidCNPJ_ShouldHandleEdgeCaseWithZeroCNPJ() {
+        long zeroCNPJ = 0L; // Edge case with zero CNPJ
+        assertFalse(CodigoUtil.isValidCNPJ(zeroCNPJ), "Expected zero CNPJ to return false");
+    }
+
+    @Test
+    void isValidCNPJ_ShouldHandleEdgeCaseWithMaxLongValue() {
+        long maxLongCNPJ = Long.MAX_VALUE; // Edge case with max long value
+        assertFalse(CodigoUtil.isValidCNPJ(maxLongCNPJ), "Expected max long value CNPJ to return false");
+    }
+}
+import com.example.supplier.util.CodigoUtil;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@SpringBootTest
+public class CodigoUtilTest {
+
+    @Test
+    public void isValidCNPJ_ShouldReturnTrueForValidCNPJ() {
+        long validCNPJ = 12345678000195L; // Example of a valid CNPJ
+        assertTrue(CodigoUtil.isValidCNPJ(validCNPJ), "Expected valid CNPJ to return true");
+    }
+
+    @Test
+    public void isValidCNPJ_ShouldReturnFalseForInvalidCNPJ() {
+        long invalidCNPJ = 12345678000194L; // Example of an invalid CNPJ
+        assertFalse(CodigoUtil.isValidCNPJ(invalidCNPJ), "Expected invalid CNPJ to return false");
+    }
+
+    @Test
+    public void isValidCNPJ_ShouldReturnFalseForShortCNPJ() {
+        long shortCNPJ = 12345678L; // Example of a CNPJ shorter than 14 digits
+        assertFalse(CodigoUtil.isValidCNPJ(shortCNPJ), "Expected short CNPJ to return false");
+    }
+
+    @Test
+    public void isValidCNPJ_ShouldReturnFalseForLongCNPJ() {
+        long longCNPJ = 123456789012345L; // Example of a CNPJ longer than 14 digits
+        assertFalse(CodigoUtil.isValidCNPJ(longCNPJ), "Expected long CNPJ to return false");
+    }
+
+    @Test
+    public void isValidCNPJ_ShouldReturnFalseForNonNumericCNPJ() {
+        long nonNumericCNPJ = -12345678000195L; // Example of a negative CNPJ
+        assertFalse(CodigoUtil.isValidCNPJ(nonNumericCNPJ), "Expected non-numeric CNPJ to return false");
+    }
+
+    @Test
+    public void isValidCNPJ_ShouldHandleEdgeCaseWithZeroCNPJ() {
+        long zeroCNPJ = 0L; // Example of a CNPJ with all zeros
+        assertFalse(CodigoUtil.isValidCNPJ(zeroCNPJ), "Expected zero CNPJ to return false");
+    }
+
+    @Test
+    public void isValidCNPJ_ShouldHandleEdgeCaseWithMaxLongValue() {
+        long maxLongCNPJ = Long.MAX_VALUE; // Example of a CNPJ with maximum long value
+        assertFalse(CodigoUtil.isValidCNPJ(maxLongCNPJ), "Expected max long CNPJ to return false");
+    }
+
+    @Test
+    public void isValidCNPJ_ShouldHandleEdgeCaseWithMinLongValue() {
+        long minLongCNPJ = Long.MIN_VALUE; // Example of a CNPJ with minimum long value
+        assertFalse(CodigoUtil.isValidCNPJ(minLongCNPJ), "Expected min long CNPJ to return false");
+    }
+}


### PR DESCRIPTION
# ![gft_icon](https://www.gft.com/int/en/.resources/gft/webresources/img/gft-favicon.ico) Generated for GFT AI Impact Bot for the bc05e4a2f909ef4a983d7568723c940354641031

**Description:** This pull request introduces a new test class, `CodigoUtils_test.java`, which contains unit tests for the `CodigoUtil` utility class. The tests validate the behavior of the `isValidCNPJ` method under various scenarios, including valid, invalid, edge cases, and extreme values. The goal is to ensure the robustness of the `isValidCNPJ` method.

**Summary:** 
- **File Added:** `supplier-api/src/test/java/com/example/supplier/CodigoUtils_test.java`
  - **Purpose:** To test the `isValidCNPJ` method in the `CodigoUtil` class.
  - **Tests Included:**
    - Valid CNPJ: Ensures the method returns `true` for a valid CNPJ.
    - Invalid CNPJ: Ensures the method returns `false` for an invalid CNPJ.
    - Short CNPJ: Ensures the method returns `false` for a CNPJ shorter than 14 digits.
    - Long CNPJ: Ensures the method returns `false` for a CNPJ longer than 14 digits.
    - Non-numeric CNPJ: Ensures the method returns `false` for negative or non-numeric values.
    - Edge cases:
      - Zero CNPJ: Ensures the method returns `false` for a CNPJ with all zeros.
      - Maximum long value: Ensures the method returns `false` for the maximum possible long value.
      - Minimum long value: Ensures the method returns `false` for the minimum possible long value.

**Recommendation:** 
1. **Code Duplication:** The test class contains duplicate test methods. For example, the `isValidCNPJ_ShouldReturnTrueForValidCNPJ` method is defined twice. This redundancy should be removed to avoid confusion and maintain code clarity. Consolidate the tests into a single class.
2. **Test Naming Convention:** The test method names are descriptive but could be improved for consistency. Consider using a naming convention like `testIsValidCNPJ_ValidInput_ReturnsTrue` for better readability and alignment with industry standards.
3. **Edge Case Coverage:** While the edge cases are well-covered, it would be beneficial to add tests for CNPJs with special characters or whitespace to ensure the method handles such inputs gracefully.
4. **Documentation:** Add comments to explain the purpose of each test case, especially for edge cases, to help future developers understand the rationale behind the tests.

**Explanation of vulnerabilities:** 
1. **Potential Integer Overflow:** The `isValidCNPJ` method is tested with extreme values like `Long.MAX_VALUE` and `Long.MIN_VALUE`. If the method performs arithmetic operations on these values, it could lead to integer overflow. Ensure the implementation of `isValidCNPJ` handles such cases safely.
   - **Suggested Fix:** Add checks in the `isValidCNPJ` method to validate the input range before performing any operations.
     ```java
     if (cnpj < 0 || cnpj > 99999999999999L) {
         return false; // Invalid CNPJ
     }
     ```
2. **Negative Values:** The test includes negative CNPJs, which are inherently invalid. Ensure the `isValidCNPJ` method explicitly checks for negative values to avoid unexpected behavior.
   - **Suggested Fix:** Add a condition to reject negative values.
     ```java
     if (cnpj < 0) {
         return false; // Negative CNPJ is invalid
     }
     ```
3. **Non-numeric Input Handling:** Although the tests focus on numeric inputs, the `isValidCNPJ` method might encounter non-numeric inputs in real-world scenarios. Ensure the method is robust against such inputs.
   - **Suggested Fix:** Validate the input type before processing.
     ```java
     if (!(cnpj instanceof Long)) {
         throw new IllegalArgumentException("CNPJ must be a numeric value");
     }
     ```

By addressing these recommendations and vulnerabilities, the robustness and security of the `CodigoUtil` class can be significantly improved.